### PR TITLE
show card title with chapter code, if applicable

### DIFF
--- a/lib/response-types.js
+++ b/lib/response-types.js
@@ -49,7 +49,7 @@ class TextResponse {
     //const embedTitle = parts.shift();
     console.log(response);
     return {
-      title: response.name,
+      title: response.label,
       description: response.text,
       url: response.url,
       thumbnail: {
@@ -116,7 +116,7 @@ class ImageResponse extends TextResponse {
   makeEmbed(response) {
     //let parts = response.body.split('\n');
     return {
-      title: response.name,
+      title: response.label,
       url: response.url,
       image: {
         url: this.imageurl + response.imagesrc


### PR DESCRIPTION
Searching for `[[!Arya Stark]]`, I get one back. But - which one is it?

![Selection_631](https://user-images.githubusercontent.com/1410427/62016973-bc479100-b169-11e9-9968-e97db8c47efa.png)

This fix adds the chapter pack code with the card title, if applicable. (Cards that are unique in the entire data set by title will _not_ have the code suffixed)

![Selection_635](https://user-images.githubusercontent.com/1410427/62017020-eac56c00-b169-11e9-8886-da95baaaa441.png)

refs #6